### PR TITLE
Update google-play-services version

### DIFF
--- a/ABakerProject/ABaker/build.gradle
+++ b/ABakerProject/ABaker/build.gradle
@@ -45,7 +45,7 @@ uploadArchives {
 task install(dependsOn: uploadArchives)
 
 dependencies {
-    compile 'com.google.android.gms:play-services:5.0.77'
+    compile 'com.google.android.gms:play-services:5.0.89'
     compile 'org.jsoup:jsoup:1.7.3'
     compile 'org.apache.commons:commons-compress:1.8.1'
     compile 'com.viewpagerindicator:library:2.4.1@aar'


### PR DESCRIPTION
Google Play Services 5.0.77 repository has been pulled out and replaced by 5.0.89
Ref: https://groups.google.com/forum/#!msg/adt-dev/NPCx-2udgDk/5jZCkTcQ380J
